### PR TITLE
4th Assignment: Redis로 RefreshToken 발급 및 관리

### DIFF
--- a/seminar/week3/practice/build.gradle
+++ b/seminar/week3/practice/build.gradle
@@ -39,18 +39,21 @@ dependencies {
 	// Validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-	//JWT
+	// JWT
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
 
-	//Security
+	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
-	//Multipart file
+	// Multipart file
 	implementation("software.amazon.awssdk:bom:2.21.0")
 	implementation("software.amazon.awssdk:s3:2.21.0")
+
+	// Redis
+	implementation("org.springframework.boot:spring-boot-starter-data-redis:2.3.1.RELEASE")
 }
 
 tasks.named('test') {

--- a/seminar/week3/practice/src/main/java/org/sopt/practice/auth/SecurityConfig.java
+++ b/seminar/week3/practice/src/main/java/org/sopt/practice/auth/SecurityConfig.java
@@ -22,7 +22,7 @@ public class SecurityConfig {
     private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
-    private static final String[] AUTH_WHITE_LIST = {"/api/v1/member"};
+    private static final String[] AUTH_WHITE_LIST = {"/api/v1/auth/**"};
 
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/seminar/week3/practice/src/main/java/org/sopt/practice/auth/redis/domain/Token.java
+++ b/seminar/week3/practice/src/main/java/org/sopt/practice/auth/redis/domain/Token.java
@@ -1,0 +1,28 @@
+package org.sopt.practice.auth.redis.domain;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@RedisHash(value = "", timeToLive = 60 * 50 * 24 * 1000L * 14)
+@AllArgsConstructor
+@Getter
+@Builder
+public class Token {
+
+    @Id
+    private Long id;
+
+    @Indexed
+    private String refreshToken;
+
+    public static Token of(final Long id, final String refreshToken) {
+        return Token.builder()
+                .id(id)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/seminar/week3/practice/src/main/java/org/sopt/practice/auth/redis/repository/RedisTokenRepository.java
+++ b/seminar/week3/practice/src/main/java/org/sopt/practice/auth/redis/repository/RedisTokenRepository.java
@@ -2,9 +2,22 @@ package org.sopt.practice.auth.redis.repository;
 
 import java.util.Optional;
 import org.sopt.practice.auth.redis.domain.Token;
+import org.sopt.practice.common.ErrorMessage;
+import org.sopt.practice.exception.NotFoundException;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface RedisTokenRepository extends CrudRepository<Token, Long> {
+
+    default Token findByRefreshTokenOrElseThrow(final String refreshToken) {
+        return findByRefreshToken(refreshToken).orElseThrow(() -> new NotFoundException(ErrorMessage.REFRESH_TOKEN_NOT_FOUND));
+    }
+
+    default Token findByIdOrElseThrow(final Long id) {
+        return findById(id).orElseThrow(() -> new NotFoundException(ErrorMessage.REFRESH_TOKEN_NOT_FOUND));
+    }
+
     Optional<Token> findByRefreshToken(final String refreshToken);
     Optional<Token> findById(final Long id);
 }

--- a/seminar/week3/practice/src/main/java/org/sopt/practice/auth/redis/repository/RedisTokenRepository.java
+++ b/seminar/week3/practice/src/main/java/org/sopt/practice/auth/redis/repository/RedisTokenRepository.java
@@ -1,0 +1,10 @@
+package org.sopt.practice.auth.redis.repository;
+
+import java.util.Optional;
+import org.sopt.practice.auth.redis.domain.Token;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RedisTokenRepository extends CrudRepository<Token, Long> {
+    Optional<Token> findByRefreshToken(final String refreshToken);
+    Optional<Token> findById(final Long id);
+}

--- a/seminar/week3/practice/src/main/java/org/sopt/practice/common/ErrorMessage.java
+++ b/seminar/week3/practice/src/main/java/org/sopt/practice/common/ErrorMessage.java
@@ -6,18 +6,19 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorMessage {
     // 400 BAD REQUEST
-    LONGER_THAN_MAX_LENGTH(HttpStatus.BAD_REQUEST.value(), "longer than max length"),
+    LONGER_THAN_MAX_LENGTH(HttpStatus.BAD_REQUEST.value(), "최대 길이보다 깁니다."),
 
     // 401 UNAUTHORIZED
     JWT_UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED.value(), "사용자의 로그인 검증을 실패했습니다."),
 
     // 404 NOT FOUND
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "member not found"),
-    BLOG_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "blog not found"),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당하는 사용자가 없습니다."),
+    BLOG_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당하는 블로그가 없습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당하는 리프레시 토큰이 없습니다."),
     ;
 
-    private int status;
-    private String message;
+    private final int status;
+    private final String message;
 
     ErrorMessage(final int status, final String message) {
         this.status = status;

--- a/seminar/week3/practice/src/main/java/org/sopt/practice/common/jwt/JwtTokenProvider.java
+++ b/seminar/week3/practice/src/main/java/org/sopt/practice/common/jwt/JwtTokenProvider.java
@@ -20,7 +20,8 @@ import org.springframework.stereotype.Component;
 public class JwtTokenProvider {
     private static final String USER_ID = "userId";
 
-    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 14;
+    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 7;
+    private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 14;
 
     @Value("${jwt.secret}")
     private String JWT_SECRET;
@@ -32,7 +33,11 @@ public class JwtTokenProvider {
     * - authorities: null
     *  */
     public String issueAccessToken(final Authentication authentication) {
-        return generateToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME);
+        return generateAccessToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME);
+    }
+
+    public String issueRefreshToken() {
+        return generateRefreshToken(REFRESH_TOKEN_EXPIRATION_TIME);
     }
 
     /* 토큰 생성 로직
@@ -45,7 +50,7 @@ public class JwtTokenProvider {
     - signWith: 서명 설정 및 암호화
     - compact: 토큰 생성
     */
-    public String generateToken(Authentication authentication, Long tokenExpirationTime) {
+    public String generateAccessToken(Authentication authentication, Long tokenExpirationTime) {
         final Date now = new Date();
         final Claims claims = Jwts.claims()
                 .setIssuedAt(now)
@@ -57,6 +62,18 @@ public class JwtTokenProvider {
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE) // Header
                 .setClaims(claims) // Claim
                 .signWith(getSigningKey()) // Signature
+                .compact();
+    }
+
+    public String generateRefreshToken(Long tokenExpirationTime) {
+        final Date now = new Date();
+        final Claims claims = Jwts.claims()
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + tokenExpirationTime));      // 만료 시간
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .signWith(getSigningKey())
                 .compact();
     }
 

--- a/seminar/week3/practice/src/main/java/org/sopt/practice/common/jwt/JwtTokenProvider.java
+++ b/seminar/week3/practice/src/main/java/org/sopt/practice/common/jwt/JwtTokenProvider.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class JwtTokenProvider {
     private static final String USER_ID = "userId";
+    private static final String BEARER_PREFIX = "Bearer ";
 
     private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 7;
     private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 14;
@@ -58,7 +59,7 @@ public class JwtTokenProvider {
 
         claims.put(USER_ID, authentication.getPrincipal());
 
-        return Jwts.builder()
+        return BEARER_PREFIX + Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE) // Header
                 .setClaims(claims) // Claim
                 .signWith(getSigningKey()) // Signature
@@ -71,7 +72,7 @@ public class JwtTokenProvider {
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + tokenExpirationTime));      // 만료 시간
 
-        return Jwts.builder()
+        return BEARER_PREFIX + Jwts.builder()
                 .setClaims(claims)
                 .signWith(getSigningKey())
                 .compact();

--- a/seminar/week3/practice/src/main/java/org/sopt/practice/controller/AuthController.java
+++ b/seminar/week3/practice/src/main/java/org/sopt/practice/controller/AuthController.java
@@ -1,0 +1,41 @@
+package org.sopt.practice.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.practice.service.AuthService;
+import org.sopt.practice.service.dto.MemberCreateDto;
+import org.sopt.practice.service.dto.UserJoinResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping
+    public ResponseEntity<UserJoinResponse> signUp(
+            @RequestBody MemberCreateDto memberCreate
+    ) {
+        UserJoinResponse userJoinResponse = authService.signUp(memberCreate);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .header("Location", userJoinResponse.userId())
+                .body(
+                        userJoinResponse
+                );
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<UserJoinResponse> signIn(
+            @RequestHeader("X-Refresh-Token") final String refreshToken
+    ) {
+        UserJoinResponse userJoinResponse = authService.signIn(refreshToken);
+        return ResponseEntity.ok(userJoinResponse);
+    }
+}

--- a/seminar/week3/practice/src/main/java/org/sopt/practice/controller/MemberController.java
+++ b/seminar/week3/practice/src/main/java/org/sopt/practice/controller/MemberController.java
@@ -1,18 +1,12 @@
 package org.sopt.practice.controller;
 
-import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.sopt.practice.service.MemberService;
-import org.sopt.practice.service.dto.MemberCreateDto;
 import org.sopt.practice.service.dto.MemberFindDto;
-import org.sopt.practice.service.dto.UserJoinResponse;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,18 +16,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
-
-    @PostMapping
-    public ResponseEntity<UserJoinResponse> postMember(
-            @RequestBody MemberCreateDto memberCreate
-    ) {
-        UserJoinResponse userJoinResponse = memberService.createMember(memberCreate);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .header("Location", userJoinResponse.userId())
-                .body(
-                        userJoinResponse
-                );
-    }
 
     @GetMapping("/{memberId}")
     public ResponseEntity<MemberFindDto> findMemberById(

--- a/seminar/week3/practice/src/main/java/org/sopt/practice/service/AuthService.java
+++ b/seminar/week3/practice/src/main/java/org/sopt/practice/service/AuthService.java
@@ -1,0 +1,51 @@
+package org.sopt.practice.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.practice.auth.UserAuthentication;
+import org.sopt.practice.auth.redis.domain.Token;
+import org.sopt.practice.auth.redis.repository.RedisTokenRepository;
+import org.sopt.practice.common.jwt.JwtTokenProvider;
+import org.sopt.practice.domain.Member;
+import org.sopt.practice.repository.MemberRepository;
+import org.sopt.practice.service.dto.MemberCreateDto;
+import org.sopt.practice.service.dto.UserJoinResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTokenRepository redisTokenRepository;
+
+    @Transactional
+    public UserJoinResponse signUp(
+            MemberCreateDto memberCreate
+    ) {
+        Member member = memberRepository.save(
+                Member.create(memberCreate.name(), memberCreate.part(), memberCreate.age())
+        );
+        Long memberId = member.getId();
+        String accessToken = jwtTokenProvider.issueAccessToken(
+                UserAuthentication.createUserAuthentication(memberId)
+        );
+        String refreshToken = jwtTokenProvider.issueRefreshToken();
+        redisTokenRepository.save(Token.of(memberId, refreshToken));
+
+        return UserJoinResponse.of(accessToken, refreshToken, memberId.toString());
+    }
+
+    @Transactional
+    public UserJoinResponse signIn(
+            String refreshToken
+    ) {
+        Token redisToken = redisTokenRepository.findByRefreshTokenOrElseThrow(refreshToken);
+        String newAccessToken = jwtTokenProvider.issueAccessToken(
+                UserAuthentication.createUserAuthentication(redisToken.getId())
+        );
+
+        return UserJoinResponse.of(newAccessToken, refreshToken, redisToken.getId().toString());
+    }
+}

--- a/seminar/week3/practice/src/main/java/org/sopt/practice/service/MemberService.java
+++ b/seminar/week3/practice/src/main/java/org/sopt/practice/service/MemberService.java
@@ -33,7 +33,9 @@ public class MemberService {
         String accessToken = jwtTokenProvider.issueAccessToken(
                 UserAuthentication.createUserAuthentication(memberId)
         );
-        return UserJoinResponse.of(accessToken, memberId.toString());
+        String refreshToken = jwtTokenProvider.issueRefreshToken();
+
+        return UserJoinResponse.of(accessToken, refreshToken, memberId.toString());
     }
 
     /* private -> protected로 다른 서비스 레이어에서 호출할 수 있도록 수정 */

--- a/seminar/week3/practice/src/main/java/org/sopt/practice/service/MemberService.java
+++ b/seminar/week3/practice/src/main/java/org/sopt/practice/service/MemberService.java
@@ -1,16 +1,11 @@
 package org.sopt.practice.service;
 
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.sopt.practice.auth.UserAuthentication;
 import org.sopt.practice.common.ErrorMessage;
-import org.sopt.practice.common.jwt.JwtTokenProvider;
 import org.sopt.practice.domain.Member;
 import org.sopt.practice.exception.NotFoundException;
 import org.sopt.practice.repository.MemberRepository;
-import org.sopt.practice.service.dto.MemberCreateDto;
 import org.sopt.practice.service.dto.MemberFindDto;
-import org.sopt.practice.service.dto.UserJoinResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,24 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-    private final JwtTokenProvider jwtTokenProvider;
-
-
-    @Transactional
-    public UserJoinResponse createMember(
-            MemberCreateDto memberCreate
-    ) {
-        Member member = memberRepository.save(
-                Member.create(memberCreate.name(), memberCreate.part(), memberCreate.age())
-        );
-        Long memberId = member.getId();
-        String accessToken = jwtTokenProvider.issueAccessToken(
-                UserAuthentication.createUserAuthentication(memberId)
-        );
-        String refreshToken = jwtTokenProvider.issueRefreshToken();
-
-        return UserJoinResponse.of(accessToken, refreshToken, memberId.toString());
-    }
 
     /* private -> protected로 다른 서비스 레이어에서 호출할 수 있도록 수정 */
     protected Member findMemberById(final Long memberId) {

--- a/seminar/week3/practice/src/main/java/org/sopt/practice/service/dto/UserJoinResponse.java
+++ b/seminar/week3/practice/src/main/java/org/sopt/practice/service/dto/UserJoinResponse.java
@@ -1,8 +1,11 @@
 package org.sopt.practice.service.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 public record UserJoinResponse(
         String accessToken,
         String refreshToken,
+        @JsonIgnore
         String userId
 ) {
 

--- a/seminar/week3/practice/src/main/java/org/sopt/practice/service/dto/UserJoinResponse.java
+++ b/seminar/week3/practice/src/main/java/org/sopt/practice/service/dto/UserJoinResponse.java
@@ -2,13 +2,15 @@ package org.sopt.practice.service.dto;
 
 public record UserJoinResponse(
         String accessToken,
+        String refreshToken,
         String userId
 ) {
 
     public static UserJoinResponse of(
             String accessToken,
+            String refreshToken,
             String userId
     ) {
-        return new UserJoinResponse(accessToken, userId);
+        return new UserJoinResponse(accessToken, refreshToken, userId);
     }
 }


### PR DESCRIPTION
- closes #11 
## 이 주의 과제
- RefreshToken을 발급
- 발급한 RefreshToken을 Redis에 저장
- reissue 요청 시 Redis에 저장된 RefreshToken 값들 중 클라이언트의 RefreshToken과 일치하는 값을 조회 -> accessToken 재발급

### 요구사항 분석
- AuthController / AuthService 정의
: 사용자의 인증/인가 관련 로직은 Auth에서, 그 외 사용자 관련 로직(아이디로 멤버 정보 조회 등)은 Member의 Controller/Service에서 처리하도록 두 도메인을 분리, white list도 `/api/v1/auth`로 변경

- RefreshToken 발급 로직 구현
: 회원가입 시 accessToken과 함께 RefreshToken도 발급하여 응답, RefreshToken은 유저 정보 포함 X

- Redis로 RefreshToken 관리
: reissue 요청 발생 시 헤더의 X-Refresh-Token 값으로 오는 refreshToken을 redis에서 조회 시도,
조회가 안되면 예외 발생, 조회가 되면 accessToken 재발급 및 반환

## 질문있어요!
1. 만약 RefreshToken까지 만료되었다면, 사용자가 다시 로그인을 할 수 있게끔 예외 메세지(ex. 재 로그인이 필요합니다.)를 추가로 정의하여 응답하는 것이 좋을까요? 이렇게 재 로그인을 요구하는 경우는 클라이언트가 서버로부터 어떤 응답을 받아서 어떻게 사용자에게 다시 로그인하라는 화면을 렌더하게 되는 것인지 알고 싶습니다.
